### PR TITLE
Fix include installs

### DIFF
--- a/bionic/debian/not-installed
+++ b/bionic/debian/not-installed
@@ -1,0 +1,1 @@
+../../ubuntu/debian/not-installed

--- a/debian/sid/debian/not-installed
+++ b/debian/sid/debian/not-installed
@@ -1,0 +1,1 @@
+../../../ubuntu/debian/not-installed

--- a/focal/debian/not-installed
+++ b/focal/debian/not-installed
@@ -1,0 +1,1 @@
+../../ubuntu/debian/not-installed

--- a/ubuntu/debian/libignition-common-av-dev.install
+++ b/ubuntu/debian/libignition-common-av-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/av.hh
 usr/include/ignition/common*/ignition/common/av/*
+usr/include/ignition/common*/gz/common/av.hh
+usr/include/ignition/common*/gz/common/av/*
 usr/lib/*/cmake/ignition-common[0-99]-av/*
 usr/lib/*/libignition-common[0-99]-av.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-av.pc

--- a/ubuntu/debian/libignition-common-av-dev.install
+++ b/ubuntu/debian/libignition-common-av-dev.install
@@ -1,7 +1,5 @@
-usr/include/ignition/common*/ignition/common/av.hh
-usr/include/ignition/common*/ignition/common/av/*
-usr/include/ignition/common*/gz/common/av.hh
-usr/include/ignition/common*/gz/common/av/*
+usr/include/ignition/common*/*/common/av.hh
+usr/include/ignition/common*/*/common/av/*
 usr/lib/*/cmake/ignition-common[0-99]-av/*
 usr/lib/*/libignition-common[0-99]-av.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-av.pc

--- a/ubuntu/debian/libignition-common-core-dev.install
+++ b/ubuntu/debian/libignition-common-core-dev.install
@@ -1,8 +1,6 @@
-usr/include/ignition/common[0-99]/ignition/common.hh
-usr/include/ignition/common[0-99]/ignition/common/*.hh
-usr/include/ignition/common[0-99]/gz/common.hh
-usr/include/ignition/common[0-99]/gz/common/*.hh
-usr/include/ignition/common[0-99]/gz/common/detail/*.hh
+usr/include/ignition/common[0-99]/*/common.hh
+usr/include/ignition/common[0-99]/*/common/*.hh
+usr/include/ignition/common[0-99]/*/common/detail/*.hh
 usr/lib/*/libignition-common[0-99].so
 usr/lib/*/pkgconfig/ignition-common[0-99].pc
 usr/lib/*/cmake/ignition-common[0-99]/ignition-common*

--- a/ubuntu/debian/libignition-common-core-dev.install
+++ b/ubuntu/debian/libignition-common-core-dev.install
@@ -1,6 +1,8 @@
 usr/include/ignition/common[0-99]/ignition/common.hh
 usr/include/ignition/common[0-99]/ignition/common/*.hh
-usr/include/ignition/common[0-99]/ignition/common/detail/*.hh
+usr/include/ignition/common[0-99]/gz/common.hh
+usr/include/ignition/common[0-99]/gz/common/*.hh
+usr/include/ignition/common[0-99]/gz/common/detail/*.hh
 usr/lib/*/libignition-common[0-99].so
 usr/lib/*/pkgconfig/ignition-common[0-99].pc
 usr/lib/*/cmake/ignition-common[0-99]/ignition-common*

--- a/ubuntu/debian/libignition-common-events-dev.install
+++ b/ubuntu/debian/libignition-common-events-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/events.hh
 usr/include/ignition/common*/ignition/common/events/*
+usr/include/ignition/common*/gz/common/events.hh
+usr/include/ignition/common*/gz/common/events/*
 usr/lib/*/cmake/ignition-common[0-99]-events/*
 usr/lib/*/libignition-common[0-99]-events.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-events.pc

--- a/ubuntu/debian/libignition-common-events-dev.install
+++ b/ubuntu/debian/libignition-common-events-dev.install
@@ -1,7 +1,5 @@
-usr/include/ignition/common*/ignition/common/events.hh
-usr/include/ignition/common*/ignition/common/events/*
-usr/include/ignition/common*/gz/common/events.hh
-usr/include/ignition/common*/gz/common/events/*
+usr/include/ignition/common*/*/common/events.hh
+usr/include/ignition/common*/*/common/events/*
 usr/lib/*/cmake/ignition-common[0-99]-events/*
 usr/lib/*/libignition-common[0-99]-events.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-events.pc

--- a/ubuntu/debian/libignition-common-graphics-dev.install
+++ b/ubuntu/debian/libignition-common-graphics-dev.install
@@ -1,5 +1,7 @@
 usr/include/ignition/common*/ignition/common/graphics.hh
 usr/include/ignition/common*/ignition/common/graphics/*
+usr/include/ignition/common*/gz/common/graphics.hh
+usr/include/ignition/common*/gz/common/graphics/*
 usr/lib/*/cmake/ignition-common[0-99]-graphics/*
 usr/lib/*/libignition-common[0-99]-graphics.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-graphics.pc

--- a/ubuntu/debian/libignition-common-graphics-dev.install
+++ b/ubuntu/debian/libignition-common-graphics-dev.install
@@ -1,7 +1,5 @@
-usr/include/ignition/common*/ignition/common/graphics.hh
-usr/include/ignition/common*/ignition/common/graphics/*
-usr/include/ignition/common*/gz/common/graphics.hh
-usr/include/ignition/common*/gz/common/graphics/*
+usr/include/ignition/common*/*/common/graphics.hh
+usr/include/ignition/common*/*/common/graphics/*
 usr/lib/*/cmake/ignition-common[0-99]-graphics/*
 usr/lib/*/libignition-common[0-99]-graphics.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-graphics.pc

--- a/ubuntu/debian/libignition-common-profiler-dev.install
+++ b/ubuntu/debian/libignition-common-profiler-dev.install
@@ -1,4 +1,5 @@
 usr/include/ignition/common*/ignition/common/profiler/*
+usr/include/ignition/common*/gz/common/profiler/*
 usr/lib/*/cmake/ignition-common[0-99]-profiler/*
 usr/lib/*/libignition-common[0-99]-profiler.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-profiler.pc

--- a/ubuntu/debian/libignition-common-profiler-dev.install
+++ b/ubuntu/debian/libignition-common-profiler-dev.install
@@ -1,5 +1,4 @@
-usr/include/ignition/common*/ignition/common/profiler/*
-usr/include/ignition/common*/gz/common/profiler/*
+usr/include/ignition/common*/*/common/profiler/*
 usr/lib/*/cmake/ignition-common[0-99]-profiler/*
 usr/lib/*/libignition-common[0-99]-profiler.so
 usr/lib/*/pkgconfig/ignition-common[0-99]-profiler.pc

--- a/ubuntu/debian/not-installed
+++ b/ubuntu/debian/not-installed
@@ -1,0 +1,2 @@
+# Seems like a bug in the buildsystem
+usr/include/ignition/common3/CMakeLists.txt


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

The common 3.15.0 releases were failing: https://build.osrfoundation.org/job/ign-common3-debbuilder/1052/consoleFull#13926175386ea37b8d-a6d4-40ae-8431-d90c018842af. 

I think this fixes the issue.