### PR TITLE
rules: fix conflicts with gz header files

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -19,6 +19,9 @@ override_dh_auto_configure:
 override_dh_install:
 	dh_install --
 	# need to remove files present in components
+	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/gz/common/av.hh
+	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/gz/common/events.hh
+	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/gz/common/graphics.hh
 	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/ignition/common/av.hh
 	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/ignition/common/events.hh
 	$(RM) debian/libignition-common3-core-dev/usr/include/ignition/common*/ignition/common/graphics.hh


### PR DESCRIPTION
The 3.15.0 debian packages are currently broken:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-pr_any-ubuntu_auto-amd64-gpu-nvidia&build=1043)](https://build.osrfoundation.org/job/gazebo-ci-pr_any-ubuntu_auto-amd64-gpu-nvidia/1043/) https://build.osrfoundation.org/job/gazebo-ci-pr_any-ubuntu_auto-amd64-gpu-nvidia/1043/

~~~
dpkg: error processing archive /tmp/apt-dpkg-install-nVDKGs/554-libignition-common3-events-dev_3.15.0-1~bionic_amd64.deb (--unpack):
 trying to overwrite '/usr/include/ignition/common3/gz/common/events.hh', which is also in package libignition-common3-core-dev:amd64 3.15.0-1~bionic
~~~

The following error is in the debbuild job:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-common3-debbuilder&build=1055)](https://build.osrfoundation.org/job/ign-common3-debbuilder/1055/) https://build.osrfoundation.org/job/ign-common3-debbuilder/1055/

~~~
W: ignition-common3 source: binaries-have-file-conflict libignition-common3-av-dev libignition-common3-core-dev usr/include/ignition/common3/gz/common/av.hh
W: ignition-common3 source: binaries-have-file-conflict libignition-common3-core-dev libignition-common3-events-dev usr/include/ignition/common3/gz/common/events.hh
W: ignition-common3 source: binaries-have-file-conflict libignition-common3-core-dev libignition-common3-graphics-dev usr/include/ignition/common3/gz/common/graphics.hh
~~~

There are some statements in the `rules` file that remove duplicate `include/ignition/*` files from the `-core-dev` package, but we need to repeat those statements for the corresponding `include/gz/*` files.